### PR TITLE
Styled Layout, removed homepage containers

### DIFF
--- a/machinerepairs/src/app/globals.css
+++ b/machinerepairs/src/app/globals.css
@@ -25,7 +25,7 @@ body {
 }
 
 h1 {
-	@apply text-3xl;
+	@apply mb-[calc(3vh)] w-auto border-b-[1px] pb-2 text-3xl;
 }
 
 h2 {

--- a/machinerepairs/src/app/layout.js
+++ b/machinerepairs/src/app/layout.js
@@ -31,7 +31,11 @@ export default function RootLayout({ children }) {
 					</div>
 				</header>
 				<main className="h-[calc(100vh-20vh)] min-h-[calc(100vh-30vh)]">
-					{children}
+					<div className="grid h-full grid-cols-1">
+						<div className="w-[calc(95vw)] self-start justify-self-center md:w-3/4 ">
+							{children}
+						</div>
+					</div>
 				</main>
 			</body>
 		</html>

--- a/machinerepairs/src/app/page.js
+++ b/machinerepairs/src/app/page.js
@@ -6,22 +6,18 @@ export default function Home() {
 	const buttonItemSpacing = 'mt-3';
 
 	return (
-		<div className="grid h-full grid-cols-1">
-			<div className="w-[calc(95vw)] self-start justify-self-center md:w-3/4 ">
-				<h1 className={`mb-[calc(3vh)] w-auto border-b-[1px] pb-2`}>
-					Machine Repairs
-				</h1>
-				<h2>NOTES TO SELF</h2>
-				<ul className="ml-5 list-disc">
-					<li>
-						<p className="mb-5">
-							make sure to <em>require</em> users to select a branch. Then store
-							that data into localstorage.
-						</p>
-					</li>
-				</ul>
-				<HomeButtons id="homepageButtons" />
-			</div>
+		<div>
+			<h1>Machine Repairs</h1>
+			<h2>NOTES TO SELF</h2>
+			<ul className="ml-5 list-disc">
+				<li>
+					<p className="mb-5">
+						make sure to <em>require</em> users to select a branch. Then store
+						that data into localstorage.
+					</p>
+				</li>
+			</ul>
+			<HomeButtons id="homepageButtons" />
 		</div>
 	);
 }


### PR DESCRIPTION
Noticed that some elements were unnecessary in the homepage styling and were better suited to be applied to the layout for the RootLayout. In this fashion, all pages coming off the root layout will be correctly styled for the centering of elements on the page.